### PR TITLE
Add cargo support

### DIFF
--- a/colcon_ros/task/ament_cargo/__init__.py
+++ b/colcon_ros/task/ament_cargo/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2018 Easymov Robotics
+# Licensed under the Apache License, Version 2.0
+
+import os
+import shutil
+
+from colcon_core.environment_variable import EnvironmentVariable
+
+"""Environment variable to override the Cargo executable"""
+CARGO_COMMAND_ENVIRONMENT_VARIABLE = EnvironmentVariable(
+    'CARGO_COMMAND', 'The full path to the Cargo executable')
+
+
+def which_executable(environment_variable, executable_name):
+    """
+    Determine the path of an executable.
+
+    An environment variable can be used to override the location instead of
+    relying on searching the PATH.
+    :param str environment_variable: The name of the environment variable
+    :param str executable_name: The name of the executable
+    :rtype: str
+    """
+    value = os.getenv(environment_variable)
+    if value:
+        return value
+    return shutil.which(executable_name)
+
+
+CARGO_EXECUTABLE = which_executable(
+    CARGO_COMMAND_ENVIRONMENT_VARIABLE.name, 'cargo')

--- a/colcon_ros/task/ament_cargo/build.py
+++ b/colcon_ros/task/ament_cargo/build.py
@@ -1,0 +1,145 @@
+# Copyright 2018 Easymov Robotics
+# Licensed under the Apache License, Version 2.0
+
+import os
+import shutil
+from pathlib import Path
+
+from colcon_ros.task.ament_cargo import CARGO_EXECUTABLE
+from colcon_core.environment import create_environment_scripts
+from colcon_core.logging import colcon_logger
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.shell import create_environment_hook, get_command_environment
+from colcon_core.task import run
+from colcon_core.task import TaskExtensionPoint
+
+import toml
+
+logger = colcon_logger.getChild(__name__)
+
+
+class AmentCargoBuildTask(TaskExtensionPoint):
+    """Build Cargo packages."""
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(TaskExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):  # noqa: D102
+        parser.add_argument(
+            '--cargo-args',
+            nargs='*', metavar='*', type=str.lstrip,
+            help='Pass arguments to Cargo projects. '
+            'Arguments matching other options must be prefixed by a space,\n'
+            'e.g. --cargo-args " --help"')
+
+    async def build(  # noqa: D102
+        self, *, additional_hooks=[], skip_hook_creation=False
+    ):
+        pkg = self.context.pkg
+        args = self.context.args
+
+        logger.info(
+            "Building Cargo package in '{args.path}'".format_map(locals()))
+
+        try:
+            env = await get_command_environment(
+                'build', args.build_base, self.context.dependencies)
+        except RuntimeError as e:
+            logger.error(str(e))
+            return 1
+
+        self.progress('prepare')
+        rc = self.prepare_build_dir(env)
+        if rc != 0:
+            return rc
+        self.progress('build')
+
+        root_dir = os.path.join(
+            args.install_base, 'lib', self.context.pkg.name)
+
+        # invoke build step
+        if CARGO_EXECUTABLE is None:
+            raise RuntimeError("Could not find 'cargo' executable")
+        cargo_args = self.context.args.cargo_args
+        if cargo_args is None:
+            cargo_args = []
+        cmd = [
+            CARGO_EXECUTABLE, 'ros-install',
+            '--manifest-path', args.build_base + '/Cargo.toml',
+            '--install-base', args.install_base
+            ] + cargo_args
+
+        rc = await run(
+            self.context, cmd, cwd=args.build_base, env=env)
+        if rc and rc.returncode:
+            return rc.returncode
+
+        additional_hooks = create_environment_hook(
+            'ament_prefix_path', Path(args.install_base),
+            self.context.pkg.name, 'AMENT_PREFIX_PATH', '', mode='prepend')
+
+        if not skip_hook_creation:
+            create_environment_scripts(
+                pkg, args, additional_hooks=additional_hooks)
+        
+
+    def prepare_build_dir(self, env):
+        prefixes, unresolved = resolve_prefixes(env, self.context.pkg.get_dependencies())
+
+        # Clean up build dir
+        build_dir = Path(self.context.args.build_base)
+        if build_dir.exists():
+            shutil.rmtree(build_dir)
+        build_dir.mkdir(parents=True)
+
+        # Write the resolved Cargo.toml
+        content = {}
+        cargo_toml = self.context.pkg.path / 'Cargo.toml.in'
+        try:
+            content = toml.load(str(cargo_toml))
+        except toml.TomlDecodeError:
+            logger.error('Decoding error when processing "%s"'
+                         % cargo_toml.absolute())
+            return 1
+
+        for dep in self.context.pkg.get_dependencies():
+            prefix = prefixes.get(dep)
+            if prefix is None:
+                logger.info("Dependency '{}' is not a Rust crate and is not added to Cargo.toml.".format(dep))
+                continue
+            dep_location = prefix / 'share' / dep / 'rust'
+            content['dependencies'][dep] = {'path': str(dep_location)}
+        cargo_toml_out = build_dir / 'Cargo.toml'
+        toml.dump(content, cargo_toml_out.open('w'))
+
+        # symlink the source folder
+        src_dir = Path(self.context.pkg.path).resolve()
+        # hacky
+        (build_dir / 'src').symlink_to(src_dir / 'src')
+        if (src_dir / 'build.rs').is_file():
+            (build_dir / 'build.rs').symlink_to(src_dir / 'build.rs')
+        return 0
+
+
+def resolve_prefixes(env, dependencies):
+    """
+    Find out which prefix contains each of the dependencies.
+
+    :param env: environment dict for this package 
+    :param dependencies: package names of dependencies
+    :returns: A mapping of dependencies to prefixes and a list of dependencies
+    that were not found.
+    :rtype Tuple[dict(str, Path), list(path)]
+    """
+    prefix_for_dependency = {}
+    for prefix in env['AMENT_PREFIX_PATH'].split(os.pathsep):
+        prefix = Path(prefix)
+        packages_dir = prefix / 'share/ament_index/resource_index/rust_crates'
+        packages = set(path.name for path in packages_dir.iterdir()) if packages_dir.exists() else set()
+        found_dependencies = packages.intersection(dependencies)
+        for pkg in found_dependencies:
+            prefix_for_dependency[pkg] = prefix
+        dependencies -= found_dependencies
+
+    return prefix_for_dependency, dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ colcon_core.prefix_path =
     ament = colcon_ros.prefix_path.ament:AmentPrefixPath
     catkin = colcon_ros.prefix_path.catkin:CmakePrefixPath
 colcon_core.task.build =
+    ros.ament_cargo = colcon_ros.task.ament_cargo.build:AmentCargoBuildTask
     ros.ament_cmake = colcon_ros.task.ament_cmake.build:AmentCmakeBuildTask
     ros.ament_python = colcon_ros.task.ament_python.build:AmentPythonBuildTask
     ros.catkin = colcon_ros.task.catkin.build:CatkinBuildTask


### PR DESCRIPTION
I ran into some questions along the way,  here are my comments/design decisions.
* First, I saw that a package.xml is actually optional as far as colcon is concerned. I chose to keep it in the current implementation, but does anyone know if that brings any concrete benefit?
* Since the other ROS build types (i.e. build types with a `package.xml`) are in `colcon-ros` and not in individual plugins, I decided to move `colcon-cargo` into `colcon-ros`. This way, parsing dependencies from the `package.xml` file does not have to be reimplemented, and we don't have to fiddle with extension priorities.
* We need to fill in the dependency paths into `Cargo.toml`, but  I was surprised that `colcon` doesn't offer a convenient way to resolve the package name of a dependency to a path. So now, the build code looks for a marker file in the ament resource index. First, I used the existing `packages` resource type, but then noticed that it doesn't make sense to add non-Rust dependencies like `rcl` to `Cargo.toml`. So I made up a new marker file called `rust_crates`.
* The crate is symlinked into the build directory. I currently just symlink `src` and `build.rs`, but that will fail when e.g. the source dir has another name. Maybe it's better to symlink everything from the source dir, at the risk of pulling in too much junk?
* The Rust dependencies are appended to `Cargo.toml` in the build dir, the other dependencies are ignored.
* Finally, we call a `cargo` wrapper/plugin that calls `cargo build` and installs everything into the install dir. We could do the installation in `colcon-ros` theoretically, but (a) I think it's discouraged (see https://github.com/colcon/colcon-ros/pull/74) and (b) it keeps the build modular, making it possible to create all the files ROS expects even if you just want to use `cargo` alone.